### PR TITLE
Upgraded deprecated Gdk.color.parse to newer Gdk.color_parse

### DIFF
--- a/BlockParty.py
+++ b/BlockParty.py
@@ -83,7 +83,7 @@ class BlockParty:
 
     bw, bh, gridwidth = 11, 20, 1
 
-    colors = [Color(Gdk.Color.parse(i)[1]) for i in [
+    colors = [Color(Gdk.color_parse(i)) for i in [
         '#101944', 'blue', 'green', 'cyan',
         'red', 'magenta', 'YellowGreen', 'white'
     ]]
@@ -150,11 +150,11 @@ class BlockParty:
         self.window.connect("key-press-event", self.keypress_cb)
         self.window.connect("key-release-event", self.keyrelease_cb)
 
-        self.color_back = Color(Gdk.Color.parse("#343e76")[1])
-        self.color_glass = Color(Gdk.Color.parse("#6e82e6")[1])
-        self.color_glass_back = Color(Gdk.Color.parse("#4960d4")[1])
-        self.color_score = Color(Gdk.Color.parse("white")[1])
-        self.color_ui_text = Color(Gdk.Color.parse("#eeeeee")[1])
+        self.color_back = Color(Gdk.color_parse("#343e76"))
+        self.color_glass = Color(Gdk.color_parse("#6e82e6"))
+        self.color_glass_back = Color(Gdk.color_parse("#4960d4"))
+        self.color_score = Color(Gdk.color_parse("white"))
+        self.color_ui_text = Color(Gdk.color_parse("#eeeeee"))
 
         self.bwpx = int(self.window_w / (self.bw + self.bw / 2 + 2))
         self.bhpx = int(self.window_h / (self.bh + 2))


### PR DESCRIPTION
## Overview 
Gdk.color.parse has been deprecated and Gdk.color_parse is the newer function to implement the functionality and I have changed `BlockParty.py` to use the newer function instead of the deprecated one

## Description
addressing #29 Gdk.color.parse has been deprecated since version 3.14 as mentioned [here](https://docs.gtk.org/gdk3/type_func.Color.parse.html) in the official Docs.
Gdk.color_parse achieves that functionality [(check here)](http://library.isr.ist.utl.pt/docs/pygtk2reference/class-gdkcolor.html#function-gdk--color-parse)
The implementation is a little different though as we don't need to select any element from an array like we had to when using color.parse, we can simply use the returned value as the value returned is a Gdk.Color.
