### PR TITLE
bugfix: score overflow at 4+ digits

### DIFF
--- a/BlockParty.py
+++ b/BlockParty.py
@@ -169,7 +169,7 @@ class BlockParty:
             2 - min(self.xshift / 2, 100)
         self.ynext = self.window_h / 2 - min(self.window_h / 2, 200)
 
-        self.scorex = self.xshift / 2 - min(self.xshift / 2, 100)
+        self.scorex = self.xshift / 2 - min(self.xshift / 2, 150)
         self.scorey = self.window_h / 2 - min(self.window_h / 2, 100)
 
         self.score_path = score_path


### PR DESCRIPTION
## Overview 
Highscore overflows whenever it reaches over 999

## Bug Replication steps 
1. play the game and reach a score of 1000 or above
2. notice that the high score overflows into the game screen

## Expected behaviour
The text should be shifted a little towards left so that text doesn't flow into the game box

## Screenshots 
<img width="798" alt="Screenshot_20230211_074022" src="https://user-images.githubusercontent.com/114365550/218262957-0de8d107-d022-4d91-834f-fd902fa78cf5.png">

> Above screenshot shows behavior before BugFix

<img width="797" alt="Screenshot_20230211_074307" src="https://user-images.githubusercontent.com/114365550/218262962-17313d5f-f4c2-4bc4-842d-75a0ac475353.png">

> After BugFix
